### PR TITLE
Update Api2ServiceCreator.kt

### DIFF
--- a/app/src/main/java/com/example/c001apk/logic/network/Api2ServiceCreator.kt
+++ b/app/src/main/java/com/example/c001apk/logic/network/Api2ServiceCreator.kt
@@ -9,22 +9,23 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 object Api2ServiceCreator {
 
-    private val client: OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(AddCookiesInterceptor())
-        .addInterceptor(HttpLoggingInterceptor().setLevel(if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE))
-        .build()
-
     private const val BASE_URL = "https://api2.coolapk.com"
 
-    private val retrofit = Retrofit.Builder()
+    private val httpLoggingInterceptor = HttpLoggingInterceptor().apply {
+        level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
+    }
+
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(AddCookiesInterceptor())
+        .addInterceptor(httpLoggingInterceptor)
+        .build()
+
+    private val retrofit: Retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)
         .addConverterFactory(GsonConverterFactory.create())
         .client(client)
         .build()
 
     fun <T> create(serviceClass: Class<T>): T = retrofit.create(serviceClass)
-
     inline fun <reified T> create(): T = create(T::class.java)
-
-
 }


### PR DESCRIPTION
- The instantiation of the HttpLoggingInterceptor and its configuration logic have been extracted to a separate variable named httpLoggingInterceptor. This is done using the apply function to set the log level, making the code for configuring the client more streamlined and easier to read.
- The retrofit object declaration has been simplified such that the builder pattern is used succinctly. Instead of chaining functions directly during the variable initialization, the builder configuration has been separated out for clarity.