### PR TITLE
Update ApiServiceCreator.kt

### DIFF
--- a/app/src/main/java/com/example/c001apk/logic/network/ApiServiceCreator.kt
+++ b/app/src/main/java/com/example/c001apk/logic/network/ApiServiceCreator.kt
@@ -7,39 +7,30 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-
 object ApiServiceCreator {
-
-    private val client: OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(AddCookiesInterceptor())
-        .addInterceptor(HttpLoggingInterceptor().setLevel(if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE))
-        .build()
-
-    private val clientNoRedirect: OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(AddCookiesInterceptor())
-        .addInterceptor(HttpLoggingInterceptor().setLevel(if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE))
-        .followRedirects(false)
-        .build()
-
+    
     private const val BASE_URL = "https://api.coolapk.com"
 
-    private val retrofit = Retrofit.Builder()
-        .baseUrl(BASE_URL)
-        .addConverterFactory(GsonConverterFactory.create())
-        .client(client)
-        .build()
+    private fun createOkHttpClient(followRedirects: Boolean = true): OkHttpClient =
+        OkHttpClient.Builder().apply {
+            addInterceptor(AddCookiesInterceptor())
+            addInterceptor(HttpLoggingInterceptor().apply {
+                level = if (BuildConfig.DEBUG)
+                    HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
+            })
+            followRedirects(followRedirects)
+        }.build()
 
-    private val retrofitNoRedirect = Retrofit.Builder()
-        .baseUrl(BASE_URL)
-        .addConverterFactory(GsonConverterFactory.create())
-        .client(clientNoRedirect)
-        .build()
+    private fun createRetrofit(followRedirects: Boolean): Retrofit =
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(createOkHttpClient(followRedirects))
+            .build()
 
-    fun <T> create(noredirect: Boolean, serviceClass: Class<T>): T =
-        if (noredirect) retrofitNoRedirect.create(serviceClass) else retrofit.create(serviceClass)
+    fun <T> create(serviceClass: Class<T>, noRedirect: Boolean = false): T =
+        createRetrofit(noRedirect).create(serviceClass)
 
-    inline fun <reified T> create(noredirect: Boolean = false): T =
-        create(noredirect, T::class.java)
-
-
+    inline fun <reified T> create(noRedirect: Boolean = false): T =
+        create(T::class.java, noRedirect)
 }


### PR DESCRIPTION
### OkHttpClient Initialization Refactoring

- Common client configuration code extracted into `createOkHttpClient` method, promoting reuse and reducing redundancy.
- `followRedirects` parameter added to allow easy switching of the redirect behavior during client construction.

### Retrofit Initialization Enhancement

- Created `createRetrofit` method that generates a Retrofit instance with a custom client based on `followRedirects` option.
- Integrated `createRetrofit` within the service creation workflow to centralize Retrofit setup.

### Service Creation Simplification

- Combined direct class type and reified type parameter service creation into a single generic function with default parameters.
- Inlined `create` function to leverage Kotlin's type reification, enabling concise and type-safe service instance requests.